### PR TITLE
Readme: document Lime instead of OpenFL in framework notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Note: My personal vision of `vscode-haxe` is to be a language helper, while you 
 #Framework notes
 Some frameworks support the creation of `.hxml` files, which is necessary to run the Haxe code completion engine. Below is a list of how you can get an `.hxml` file from various frameworks.
 
-Framework     | How to get .hxml                    | Example usage
-------------- | ------------------------------------|------------------------
-OpenFL        | `openfl display <platform>`         | `openfl display linux > build.hxml`
-Snow          | `haxelib run flow info --hxml`      | `haxelib run flow info --hxml > build.hxml`
-Kha           | See `build/project-<platform>.hxml` | Set location in Workspace Settings
-Flambe        | `flambe haxe-flags`                 | `flambe haxe-flags > build.hxml`
+Framework     | How to get .hxml                      | Example usage
+------------- | --------------------------------------|------------------------
+Lime          | `haxelib run lime display <platform>` | `haxelib run lime display linux > build.hxml`
+Snow          | `haxelib run flow info --hxml`        | `haxelib run flow info --hxml > build.hxml`
+Kha           | See `build/project-<platform>.hxml`   | Set location in Workspace Settings
+Flambe        | `flambe haxe-flags`                   | `flambe haxe-flags > build.hxml`
 
 Feel free to file an issue with details for other frameworks.
 


### PR DESCRIPTION
Also added the `haxelib run` - weird to have that for flow but not lime / openfl.
