### PR TITLE
Enable breakpoint for haxe file

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,16 @@
 	],
 	"main": "./haxe.js",
 	"contributes": {
+		"debuggers": [
+			{
+				"type": "haxe",
+				"label": "haxe",
+				"enableBreakpointsFor":
+				{
+					"languageIds": ["haxe"]
+				}
+            }
+        ],
 		"commands": [
 			{
 				"command": "haxe.hello",


### PR DESCRIPTION
- enable breakpoint for haxefile (need to compile with -debug parameter to enable sourcemap)
