### PR TITLE
Remove "Hello from haxe !"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,6 @@
 				}
 			}
 		],
-		"commands": [
-			{
-				"command": "haxe.hello",
-				"title": "Hello from Haxe!"
-			}
-		],
 		"languages": [
 			{
 				"id": "haxe",


### PR DESCRIPTION
I think it isn't useful to keep this command as it is not registered in the extension...
